### PR TITLE
Make preset item reactive

### DIFF
--- a/app/src/modules/settings/routes/presets/collection/collection.vue
+++ b/app/src/modules/settings/routes/presets/collection/collection.vue
@@ -253,6 +253,7 @@ export default defineComponent({
 		}
 
 		function onRowClick({ item }: { item: Preset }) {
+			item = ref(item).value;
 			if (selection.value.length === 0) {
 				router.push(`/settings/presets/${item.id}`);
 			} else {


### PR DESCRIPTION
There's an issue when a row is clicked during selection mode.
The item is not reactive, thus the comparison in filtering does not work.

https://user-images.githubusercontent.com/26413686/141465030-eb5ab395-f088-41ae-8c7a-8e040bffb952.mov

There's a warning about the collection name not being a string. I believe it's something to do with the following code, but am unsure how to go about it.

https://github.com/joselcvarela/directus/blob/af2a8d4812345ec7080487d7ad93dcf7bf723cf0/app/src/modules/settings/routes/presets/item.vue#L332-L340
